### PR TITLE
#SB-120: Assign ports to the maven-jetty-plugin, derby-maven-plugin and unboundid-maven-plugin by reserving free ones with the build-helper-maven-plugin

### DIFF
--- a/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap-core/pom.xml
+++ b/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap-core/pom.xml
@@ -16,6 +16,22 @@
 
     <name>Strongbox Authentication: LDAP [Core]</name>
 
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <organization>
+        <name>Carlspring Consulting &amp; Development Ltd.</name>
+        <url>http://www.carlspring.org/</url>
+    </organization>
+
+    <inceptionYear>2014</inceptionYear>
+
     <build>
         <plugins>
             <plugin>
@@ -42,47 +58,10 @@
                 <configuration>
                     <forkMode>once</forkMode>
                     <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
+                    <systemPropertyVariables>
+                        <port.unboundid>${port.unboundid}</port.unboundid>
+                    </systemPropertyVariables>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.carlspring.maven</groupId>
-                <artifactId>unboundid-maven-plugin</artifactId>
-                <version>1.0-SNAPSHOT</version>
-
-                <configuration>
-                    <baseDn>dc=carlspring,dc=com</baseDn>
-                    <portSSL>40636</portSSL>
-                    <useSSL>true</useSSL>
-                    <keyStorePassword>password</keyStorePassword>
-                    <keyStorePath>${basedir}/src/test/resources/etc/ssl/keystore.jks</keyStorePath>
-                    <trustStorePath>${basedir}/src/test/resources/etc/ssl/truststore.jks</trustStorePath>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <id>unboundid-start</id>
-
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>start</goal>
-                        </goals>
-
-                        <configuration>
-                            <ldifFiles>
-                                <ldifFile>${basedir}/src/test/resources/ldap/unboundid.ldif</ldifFile>
-                            </ldifFiles>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>unboundid-stop</id>
-
-                        <phase>test</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
@@ -141,4 +120,90 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>run-it-tests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>!true</value>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.9</version>
+                        <executions>
+                            <execution>
+                                <id>reserve-network-port</id>
+                                <goals>
+                                    <goal>reserve-network-port</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                                <configuration>
+                                    <portNames>
+                                        <portName>port.unboundid</portName>
+                                    </portNames>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.carlspring.maven</groupId>
+                        <artifactId>unboundid-maven-plugin</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+
+                        <configuration>
+                            <baseDn>dc=carlspring,dc=com</baseDn>
+                            <portSSL>${port.unboundid}</portSSL>
+                            <useSSL>true</useSSL>
+                            <keyStorePassword>password</keyStorePassword>
+                    <keyStorePath>${basedir}/src/test/resources/etc/ssl/keystore.jks</keyStorePath>
+                    <trustStorePath>${basedir}/src/test/resources/etc/ssl/truststore.jks</trustStorePath>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>unboundid-start</id>
+
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+
+                                <configuration>
+                                    <ldifFiles>
+                                        <ldifFile>${basedir}/src/test/resources/ldap/unboundid.ldif</ldifFile>
+                                    </ldifFiles>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>unboundid-stop</id>
+
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>set-default-ports</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <!-- Default ports for local development: -->
+                <port.unboundid>40636</port.unboundid>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap/pom.xml
+++ b/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap/pom.xml
@@ -16,7 +16,30 @@
 
     <name>Strongbox Authentication: LDAP</name>
 
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <organization>
+        <name>Carlspring Consulting &amp; Development Ltd.</name>
+        <url>http://www.carlspring.org/</url>
+    </organization>
+
+    <inceptionYear>2014</inceptionYear>
+
     <build>
+        <testResources>
+            <testResource>
+                <directory>${basedir}/src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -42,47 +65,10 @@
                 <configuration>
                     <forkMode>once</forkMode>
                     <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
+                    <systemPropertyVariables>
+                        <port.unboundid>${port.unboundid}</port.unboundid>
+                    </systemPropertyVariables>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.carlspring.maven</groupId>
-                <artifactId>unboundid-maven-plugin</artifactId>
-                <version>1.0-SNAPSHOT</version>
-
-                <configuration>
-                    <baseDn>dc=carlspring,dc=com</baseDn>
-                    <portSSL>40636</portSSL>
-                    <useSSL>true</useSSL>
-                    <keyStorePassword>password</keyStorePassword>
-                    <keyStorePath>${basedir}/src/test/resources/etc/ssl/keystore.jks</keyStorePath>
-                    <trustStorePath>${basedir}/src/test/resources/etc/ssl/truststore.jks</trustStorePath>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <id>unboundid-start</id>
-
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>start</goal>
-                        </goals>
-
-                        <configuration>
-                            <ldifFiles>
-                                <ldifFile>${basedir}/src/test/resources/ldap/unboundid.ldif</ldifFile>
-                            </ldifFiles>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>unboundid-stop</id>
-
-                        <phase>test</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
@@ -146,4 +132,91 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>run-it-tests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>!true</value>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.9</version>
+                        <executions>
+                            <execution>
+                                <id>reserve-network-port</id>
+                                <goals>
+                                    <goal>reserve-network-port</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                                <configuration>
+                                    <portNames>
+                                        <portName>port.unboundid</portName>
+                                    </portNames>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.carlspring.maven</groupId>
+                        <artifactId>unboundid-maven-plugin</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+
+                        <configuration>
+                            <baseDn>dc=carlspring,dc=com</baseDn>
+                            <portSSL>${port.unboundid}</portSSL>
+                            <useSSL>true</useSSL>
+                            <keyStorePassword>password</keyStorePassword>
+                            <keyStorePath>${basedir}/src/test/resources/etc/ssl/keystore.jks</keyStorePath>
+                            <trustStorePath>${basedir}/src/test/resources/etc/ssl/truststore.jks</trustStorePath>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>unboundid-start</id>
+
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+
+                                <configuration>
+                                    <ldifFiles>
+                                        <ldifFile>${basedir}/src/test/resources/ldap/unboundid.ldif</ldifFile>
+                                    </ldifFiles>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>unboundid-stop</id>
+
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>set-default-ports</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <!-- Default ports for local development: -->
+                <port.unboundid>40636</port.unboundid>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap/src/test/resources/etc/conf/security-authentication-ldap.xml
+++ b/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap/src/test/resources/etc/conf/security-authentication-ldap.xml
@@ -1,7 +1,7 @@
 <ldap-configuration>
 
     <host>localhost</host>
-    <port>40636</port>
+    <port>${port.unboundid}</port>
     <protocol>ldaps</protocol>
     <username>admin</username>
     <password>password</password>

--- a/strongbox-authentication/strongbox-authentication-rdbms/pom.xml
+++ b/strongbox-authentication/strongbox-authentication-rdbms/pom.xml
@@ -18,51 +18,32 @@
 
     <licenses>
         <license>
-            <name>The Apache Software License, Version 2.0</name>
+            <name>Apache 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
 
-    <properties>
-        <derby.url>jdbc:derby://localhost:1527/db;user=derby;password=derby</derby.url>
+    <organization>
+        <name>Carlspring Consulting &amp; Development Ltd.</name>
+        <url>http://www.carlspring.org/</url>
+    </organization>
 
+    <inceptionYear>2014</inceptionYear>
+
+    <properties>
         <version.derby>10.10.1.1</version.derby>
         <version.spring>3.2.4.RELEASE</version.spring>
     </properties>
 
     <build>
-        <!--
         <testResources>
-            <testResource>
-                <directory>${basedir}/src/main/resources</directory>
-                <filtering>true</filtering>
-            </testResource>
             <testResource>
                 <directory>${basedir}/src/test/resources</directory>
                 <filtering>true</filtering>
             </testResource>
-            <testResource>
-                <directory>${basedir}/src/main/jetty</directory>
-                <targetPath>${project.build.directory}/jetty</targetPath>
-                <filtering>true</filtering>
-            </testResource>
-            <testResource>
-                <directory>${project.build.directory}/tmp/test-resources/META-INF/replaceables</directory>
-                <filtering>true</filtering>
-            </testResource>
-            <testResource>
-                <directory>${project.build.directory}/tmp/test-resources</directory>
-                <filtering>true</filtering>
-                <excludes>
-                    <exclude>META-INF/replaceables/**</exclude>
-                    <exclude>META-INF/maven/**</exclude>
-                    <exclude>META-INF/MANIFEST.MF</exclude>
-                </excludes>
-            </testResource>
         </testResources>
-        -->
 
         <plugins>
             <plugin>
@@ -89,72 +70,10 @@
                 <configuration>
                     <forkMode>once</forkMode>
                     <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
+                    <systemPropertyVariables>
+                        <port.unboundid>${port.derby}</port.unboundid>
+                    </systemPropertyVariables>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.carlspring.maven</groupId>
-                <artifactId>derby-maven-plugin</artifactId>
-                <version>1.9</version>
-
-                <configuration>
-                    <failIfAlreadyRunning>false</failIfAlreadyRunning>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <id>start-derby</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>start</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>sql-maven-plugin</artifactId>
-                <version>1.5</version>
-
-                <dependencies>
-                    <!-- specify the dependent jdbc driver here -->
-                    <dependency>
-                    	<groupId>org.apache.derby</groupId>
-                    	<artifactId>derby</artifactId>
-                    	<version>${version.derby}</version>
-                    </dependency>
-                    <dependency>
-                    	<groupId>org.apache.derby</groupId>
-                    	<artifactId>derbyclient</artifactId>
-                    	<version>${version.derby}</version>
-                    </dependency>
-                </dependencies>
-
-                <!-- common configuration shared by all executions -->
-                <configuration>
-                    <driver>org.apache.derby.jdbc.ClientDriver</driver>
-                    <url>${derby.url};create=true</url>
-                    <onError>continue</onError>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <id>db-populate</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <onError>abort</onError>
-                            <autocommit>true</autocommit>
-                            <srcFiles>
-                                <srcFile>${basedir}/src/test/resources/sql/derby/01-db.sql</srcFile>
-                                <srcFile>${basedir}/src/test/resources/sql/derby/02-ddl.sql</srcFile>
-                            </srcFiles>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
@@ -242,5 +161,127 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>run-it-tests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>!true</value>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <properties>
+                <derby.url>jdbc:derby://localhost:${port.derby}/db;user=derby;password=derby</derby.url>
+            </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.9</version>
+                        <executions>
+                            <execution>
+                                <id>reserve-network-port</id>
+                                <goals>
+                                    <goal>reserve-network-port</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                                <configuration>
+                                    <portNames>
+                                        <portName>port.derby</portName>
+                                    </portNames>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.carlspring.maven</groupId>
+                        <artifactId>derby-maven-plugin</artifactId>
+                        <version>1.9</version>
+
+                        <configuration>
+                            <failIfAlreadyRunning>false</failIfAlreadyRunning>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>start-derby</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+
+                                <configuration>
+                                    <port>${port.derby}</port>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>sql-maven-plugin</artifactId>
+                        <version>1.5</version>
+
+                        <dependencies>
+                            <!-- specify the dependent jdbc driver here -->
+                            <dependency>
+                            	<groupId>org.apache.derby</groupId>
+                            	<artifactId>derby</artifactId>
+                            	<version>${version.derby}</version>
+                            </dependency>
+                            <dependency>
+                            	<groupId>org.apache.derby</groupId>
+                            	<artifactId>derbyclient</artifactId>
+                            	<version>${version.derby}</version>
+                            </dependency>
+                        </dependencies>
+
+                        <!-- common configuration shared by all executions -->
+                        <configuration>
+                            <driver>org.apache.derby.jdbc.ClientDriver</driver>
+                            <url>${derby.url};create=true</url>
+                            <onError>continue</onError>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>db-populate</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <onError>abort</onError>
+                                    <autocommit>true</autocommit>
+                                    <srcFiles>
+                                        <srcFile>${basedir}/src/test/resources/sql/derby/01-db.sql</srcFile>
+                                        <srcFile>${basedir}/src/test/resources/sql/derby/02-ddl.sql</srcFile>
+                                    </srcFiles>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>set-default-ports</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <!-- Default ports for local development: -->
+                <port.derby>1527</port.derby>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/strongbox-authentication/strongbox-authentication-rdbms/src/test/resources/META-INF/properties/jdbc.properties
+++ b/strongbox-authentication/strongbox-authentication-rdbms/src/test/resources/META-INF/properties/jdbc.properties
@@ -1,7 +1,7 @@
 jdbc.username=
 jdbc.password=
 #jdbc.url=jdbc:derby:${project.build.directory}/derby/db;create=true
-jdbc.url=jdbc:derby://localhost:1527/db;user=derby;password=derby;create=true
-jdbc.url.shutdown=jdbc:derby://localhost:1527/db;create=true;user=derby;password=derby;shutdown=true
+jdbc.url=jdbc:derby://localhost:${port.derby}/db;user=derby;password=derby;create=true
+jdbc.url.shutdown=jdbc:derby://localhost:${port.derby}/db;create=true;user=derby;password=derby;shutdown=true
 jdbc.driver=org.apache.derby.jdbc.ClientDriver
 jdbc.jndi.name=ds/derby

--- a/strongbox-authentication/strongbox-authentication-rdbms/src/test/resources/etc/conf/security-authentication-rdbms.xml
+++ b/strongbox-authentication/strongbox-authentication-rdbms/src/test/resources/etc/conf/security-authentication-rdbms.xml
@@ -1,7 +1,7 @@
 <ldap-configuration>
 
     <host>localhost</host>
-    <port>1527</port>
+    <port>${port.derby}</port>
 
     <username>admin</username>
     <password>password</password>

--- a/strongbox-authentication/strongbox-authentication-xml/pom.xml
+++ b/strongbox-authentication/strongbox-authentication-xml/pom.xml
@@ -16,6 +16,22 @@
 
     <name>Strongbox Authentication: XML</name>
 
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <organization>
+        <name>Carlspring Consulting &amp; Development Ltd.</name>
+        <url>http://www.carlspring.org/</url>
+    </organization>
+
+    <inceptionYear>2014</inceptionYear>
+
     <build>
         <plugins>
             <plugin>
@@ -37,11 +53,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.15</version>
-
                 <configuration>
                     <forkMode>once</forkMode>
                     <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
+                    <systemPropertyVariables>
+                        <strongbox.basedir>${basedir}/target/strongbox</strongbox.basedir>
+                        <port.jetty.listen>${port.jetty.listen}</port.jetty.listen>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>
@@ -285,6 +303,27 @@
                     </plugin>
 
                     <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.9</version>
+                        <executions>
+                            <execution>
+                                <id>reserve-network-port</id>
+                                <goals>
+                                    <goal>reserve-network-port</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                                <configuration>
+                                    <portNames>
+                                        <portName>port.jetty.listen</portName>
+                                        <portName>port.jetty.shutdown</portName>
+                                    </portNames>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
                         <version>${version.jetty}</version>
@@ -299,11 +338,17 @@
                                 <descriptor>${dir.strongbox}/webapp/WEB-INF/web.xml</descriptor>
                             </webApp>
 
-                            <stopPort>19081</stopPort>
+                            <stopPort>${port.jetty.shutdown}</stopPort>
                             <stopKey>53AS9DS1FD8E3WEFEW9GR1ER8G2ER0WE31</stopKey>
-                            <stopWait>20</stopWait>
+                            <stopWait>10</stopWait>
+
+                            <httpConnector>
+                                <port>${port.jetty.listen}</port>
+                            </httpConnector>
 
                             <systemProperties>
+                                <force>true</force>
+
                                 <systemProperty>
                                     <name>strongbox.basedir</name>
                                     <value>${dir.strongbox}</value>
@@ -320,7 +365,10 @@
 
                             <useTestScope>true</useTestScope>
 
+                            <!-- Restore the following for SSL/HTTPSL when the time comes:
                             <jettyXml>${dir.jetty.etc}/jetty.xml,${dir.jetty.etc}/jetty-http.xml,${dir.jetty.etc}/jetty-ssl.xml,${dir.jetty.etc}/jetty-https.xml</jettyXml>
+                            -->
+                            <jettyXml>${dir.jetty.etc}/jetty.xml,${dir.jetty.etc}/jetty-http.xml</jettyXml>
                         </configuration>
 
                         <executions>
@@ -335,7 +383,7 @@
                             <execution>
                                 <id>jetty-stop</id>
 
-                                <phase>package</phase>
+                                <phase>test</phase>
                                 <goals>
                                     <goal>stop</goal>
                                 </goals>
@@ -364,6 +412,18 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>set-default-ports</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <!-- Default ports for local development: -->
+                <port.jetty.listen>48080</port.jetty.listen>
+                <port.jetty.shutdown>19081</port.jetty.shutdown>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Applied the fix to the strongbox-authentication-\* modules.
