### PR TITLE
#SB-120: Assign ports to the maven-jetty-plugin, derby-maven-plugin and unboundid-maven-plugin by reserving free ones with the build-helper-maven-plugin

### DIFF
--- a/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap-core/pom.xml
+++ b/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap-core/pom.xml
@@ -33,6 +33,13 @@
     <inceptionYear>2014</inceptionYear>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>${basedir}/src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -49,19 +56,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.15</version>
-
-                <configuration>
-                    <forkMode>once</forkMode>
-                    <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
-                    <systemPropertyVariables>
-                        <port.unboundid>${port.unboundid}</port.unboundid>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -121,13 +115,10 @@
     </dependencies>
 
     <profiles>
+        <!-- These two profiles need to be on top: -->
         <profile>
-            <id>run-it-tests</id>
+            <id>reserve-ports</id>
             <activation>
-                <property>
-                    <name>skipTests</name>
-                    <value>!true</value>
-                </property>
                 <activeByDefault>false</activeByDefault>
             </activation>
 
@@ -143,7 +134,7 @@
                                 <goals>
                                     <goal>reserve-network-port</goal>
                                 </goals>
-                                <phase>process-resources</phase>
+                                <phase>initialize</phase>
                                 <configuration>
                                     <portNames>
                                         <portName>port.unboundid</portName>
@@ -152,6 +143,39 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>set-default-ports</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>!true</value>
+                </property>
+
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <!-- Default ports for local development: -->
+                <port.unboundid>40636</port.unboundid>
+            </properties>
+        </profile>
+        <!-- These two profiles need to be on top. -->
+
+        <profile>
+            <id>run-it-tests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>!true</value>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>org.carlspring.maven</groupId>
                         <artifactId>unboundid-maven-plugin</artifactId>
@@ -162,8 +186,8 @@
                             <portSSL>${port.unboundid}</portSSL>
                             <useSSL>true</useSSL>
                             <keyStorePassword>password</keyStorePassword>
-                    <keyStorePath>${basedir}/src/test/resources/etc/ssl/keystore.jks</keyStorePath>
-                    <trustStorePath>${basedir}/src/test/resources/etc/ssl/truststore.jks</trustStorePath>
+                            <keyStorePath>${basedir}/src/test/resources/etc/ssl/keystore.jks</keyStorePath>
+                            <trustStorePath>${basedir}/src/test/resources/etc/ssl/truststore.jks</trustStorePath>
                         </configuration>
 
                         <executions>
@@ -191,19 +215,22 @@
                             </execution>
                         </executions>
                     </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.15</version>
+
+                        <configuration>
+                            <forkMode>once</forkMode>
+                            <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
+                            <systemPropertyVariables>
+                                <port.unboundid>${port.unboundid}</port.unboundid>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>set-default-ports</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-
-            <properties>
-                <!-- Default ports for local development: -->
-                <port.unboundid>40636</port.unboundid>
-            </properties>
         </profile>
     </profiles>
 </project>

--- a/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap/pom.xml
+++ b/strongbox-authentication/strongbox-authentication-ldap-impls/strongbox-authentication-ldap/pom.xml
@@ -57,19 +57,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.15</version>
-
-                <configuration>
-                    <forkMode>once</forkMode>
-                    <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
-                    <systemPropertyVariables>
-                        <port.unboundid>${port.unboundid}</port.unboundid>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -133,13 +120,10 @@
     </dependencies>
 
     <profiles>
+        <!-- These two profiles need to be on top: -->
         <profile>
-            <id>run-it-tests</id>
+            <id>reserve-ports</id>
             <activation>
-                <property>
-                    <name>skipTests</name>
-                    <value>!true</value>
-                </property>
                 <activeByDefault>false</activeByDefault>
             </activation>
 
@@ -164,7 +148,39 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>set-default-ports</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>!true</value>
+                </property>
 
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <!-- Default ports for local development: -->
+                <port.unboundid>40636</port.unboundid>
+            </properties>
+        </profile>
+        <!-- These two profiles need to be on top. -->
+
+        <profile>
+            <id>run-it-tests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>!true</value>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>org.carlspring.maven</groupId>
                         <artifactId>unboundid-maven-plugin</artifactId>
@@ -204,19 +220,22 @@
                             </execution>
                         </executions>
                     </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.15</version>
+
+                        <configuration>
+                            <forkMode>once</forkMode>
+                            <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
+                            <systemPropertyVariables>
+                                <port.unboundid>${port.unboundid}</port.unboundid>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>set-default-ports</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-
-            <properties>
-                <!-- Default ports for local development: -->
-                <port.unboundid>40636</port.unboundid>
-            </properties>
         </profile>
     </profiles>
 </project>

--- a/strongbox-authentication/strongbox-authentication-rdbms/pom.xml
+++ b/strongbox-authentication/strongbox-authentication-rdbms/pom.xml
@@ -71,7 +71,7 @@
                     <forkMode>once</forkMode>
                     <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
                     <systemPropertyVariables>
-                        <port.unboundid>${port.derby}</port.unboundid>
+                        <port.derby>${port.derby}</port.derby>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -267,13 +267,16 @@
                             </execution>
                         </executions>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>set-default-ports</id>
             <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>!true</value>
+                </property>
                 <activeByDefault>true</activeByDefault>
             </activation>
 

--- a/strongbox-authentication/strongbox-authentication-xml/pom.xml
+++ b/strongbox-authentication/strongbox-authentication-xml/pom.xml
@@ -33,6 +33,13 @@
     <inceptionYear>2014</inceptionYear>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>${basedir}/src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -49,18 +56,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkMode>once</forkMode>
-                    <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
-                    <systemPropertyVariables>
-                        <strongbox.basedir>${basedir}/target/strongbox</strongbox.basedir>
-                        <port.jetty.listen>${port.jetty.listen}</port.jetty.listen>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -175,6 +170,57 @@
     </dependencies>
 
     <profiles>
+        <!-- These two profiles need to be on top: -->
+        <profile>
+            <id>reserve-ports</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.9</version>
+                        <executions>
+                            <execution>
+                                <id>reserve-network-port</id>
+                                <goals>
+                                    <goal>reserve-network-port</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                                <configuration>
+                                    <portNames>
+                                        <portName>port.jetty.listen</portName>
+                                        <portName>port.jetty.shutdown</portName>
+                                    </portNames>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>set-default-ports</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>!true</value>
+                </property>
+
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <!-- Default ports for local development: -->
+                <port.jetty.listen>48080</port.jetty.listen>
+                <port.jetty.shutdown>19081</port.jetty.shutdown>
+            </properties>
+        </profile>
+        <!-- These two profiles need to be on top. -->
+
         <profile>
             <id>run-it-tests</id>
             <activation>
@@ -303,27 +349,6 @@
                     </plugin>
 
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>1.9</version>
-                        <executions>
-                            <execution>
-                                <id>reserve-network-port</id>
-                                <goals>
-                                    <goal>reserve-network-port</goal>
-                                </goals>
-                                <phase>process-resources</phase>
-                                <configuration>
-                                    <portNames>
-                                        <portName>port.jetty.listen</portName>
-                                        <portName>port.jetty.shutdown</portName>
-                                    </portNames>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
                         <version>${version.jetty}</version>
@@ -352,6 +377,10 @@
                                 <systemProperty>
                                     <name>strongbox.basedir</name>
                                     <value>${dir.strongbox}</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <name>repository.config.xml</name>
+                                    <value>${dir.strongbox}/etc/conf/strongbox.xml</value>
                                 </systemProperty>
                                 <systemProperty>
                                     <name>strongbox.storage.booter.basedir</name>
@@ -389,6 +418,32 @@
                                 </goals>
                             </execution>
                         </executions>
+
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.eclipse.jetty</groupId>
+                                <artifactId>jetty-util</artifactId>
+                                <version>${version.jetty}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.eclipse.jetty</groupId>
+                                <artifactId>jetty-runner</artifactId>
+                                <version>${version.jetty}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <forkMode>once</forkMode>
+                            <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}/login.conf</argLine>
+                            <systemPropertyVariables>
+                                <strongbox.basedir>${basedir}/target/strongbox</strongbox.basedir>
+                                <port.jetty.listen>${port.jetty.listen}</port.jetty.listen>
+                            </systemPropertyVariables>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -412,18 +467,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>set-default-ports</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-
-            <properties>
-                <!-- Default ports for local development: -->
-                <port.jetty.listen>48080</port.jetty.listen>
-                <port.jetty.shutdown>19081</port.jetty.shutdown>
-            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
These are some further fixes, therefore a new pull request.
